### PR TITLE
Revamp Blockservice Mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ a fork of `ipfs/go-blockservice` optimized for usage with TemporalX.
 
 * WriteThrough and non-WriteThrough blockservice are condensed into the same one. We leverage the underlying blockstore has logic to avoid excessive writes to disk, and to determine what we need to announce to the network. Only blocks we do not have previously will be announced to the network
 * Remove `ipfs/go-log` and use `uber-go/zap` instead
+* Allow insecure hash functions
+  * The point of not allowing insecure hash functions is somewhat useful in public networks, but insecure hash functions are often used within enterprise environments (checksum, short lived cache keys, etc...)
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 a fork of `ipfs/go-blockservice` optimized for usage with TemporalX.
 
+# Modifications
+
+* WriteThrough and non-WriteThrough blockservice are condensed into the same one. We leverage the underlying blockstore has logic to avoid excessive writes to disk, and to determine what we need to announce to the network. Only blocks we do not have previously will be announced to the network
+* Remove `ipfs/go-log` and use `uber-go/zap` instead
+
 # License
 
 All original code is licensed as it is upstream, modifications are licensed under AGPL-v3 and will be marked accordingly

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ a fork of `ipfs/go-blockservice` optimized for usage with TemporalX.
 
 # Modifications
 
-* WriteThrough and non-WriteThrough blockservice are condensed into the same one. We leverage the underlying blockstore has logic to avoid excessive writes to disk, and to determine what we need to announce to the network. Only blocks we do not have previously will be announced to the network
+* WriteThrough and non-WriteThrough blockservice are condensed into the same one. We leverage the underlying blockstore logic to avoid excessive writes to disk, and to determine what we need to announce to the network. Only blocks we do not have previously will be announced to the network
 * Remove `ipfs/go-log` and use `uber-go/zap` instead
 * Allow insecure hash functions
   * The point of not allowing insecure hash functions is somewhat useful in public networks, but insecure hash functions are often used within enterprise environments (checksum, short lived cache keys, etc...)

--- a/blockservice.go
+++ b/blockservice.go
@@ -92,25 +92,7 @@ func (s *blockService) Exchange() exchange.Interface {
 // AddBlock adds a particular block to the service, Putting it into the datastore.
 // TODO pass a context into this if the remote.HasBlock is going to remain here.
 func (s *blockService) AddBlock(o blocks.Block) error {
-	var doAnnounce bool
-	if has, err := s.blockstore.Has(o.Cid()); err != nil {
-		return err
-	} else if !has {
-		// only announce if we do not have
-		doAnnounce = true
-	}
-
-	if err := s.blockstore.Put(o); err != nil {
-		return err
-	}
-
-	if s.exchange != nil && doAnnounce {
-		if err := s.exchange.HasBlock(o); err != nil {
-			s.logger.Error("HasBlock failed", zap.Error(err))
-		}
-	}
-
-	return nil
+	return s.AddBlocks([]blocks.Block{o})
 }
 
 func (s *blockService) AddBlocks(bs []blocks.Block) error {

--- a/blockservice.go
+++ b/blockservice.go
@@ -127,7 +127,7 @@ func (s *blockService) AddBlocks(bs []blocks.Block) error {
 		}
 	}
 
-	var toAnnounce = make([]blocks.Block, len(bs))
+	var toAnnounce = make([]blocks.Block, 0, len(bs))
 	for _, b := range bs {
 		if has, err := s.blockstore.Has(b.Cid()); err != nil {
 			return err
@@ -180,10 +180,9 @@ func getBlock(ctx context.Context, c cid.Cid, bs blockstore.Blockstore, fget fun
 		// TODO be careful checking ErrNotFound. If the underlying
 		// implementation changes, this will break.
 		blk, err := fget().GetBlock(ctx, c)
-		if err != nil {
-			if err == blockstore.ErrNotFound {
-				return nil, ErrNotFound
-			}
+		if err != nil && err == blockstore.ErrNotFound {
+			return nil, ErrNotFound
+		} else if err != nil {
 			return nil, err
 		}
 		return blk, nil
@@ -262,8 +261,7 @@ func getBlocks(ctx context.Context, ks []cid.Cid, bs blockstore.Blockstore, fget
 
 // DeleteBlock deletes a block in the blockservice from the datastore
 func (s *blockService) DeleteBlock(c cid.Cid) error {
-	err := s.blockstore.DeleteBlock(c)
-	return err
+	return s.blockstore.DeleteBlock(c)
 }
 
 func (s *blockService) Close() error {

--- a/blockservice_test.go
+++ b/blockservice_test.go
@@ -42,6 +42,9 @@ func TestBlockservice(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	if err := bserv.Close(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestGetBlocks(t *testing.T) {

--- a/blockservice_test.go
+++ b/blockservice_test.go
@@ -168,6 +168,7 @@ func TestLazySessionInitialization(t *testing.T) {
 			block2.Cid(),
 			block3.Cid(),
 			block4.Cid(),
+			// this shouldn't show up as it does not exist anywhere
 			bgen.Next().Cid(),
 		},
 	)

--- a/blockservice_test.go
+++ b/blockservice_test.go
@@ -21,7 +21,7 @@ func TestWriteThroughWorks(t *testing.T) {
 	}
 	bstore2 := blockstore.NewBlockstore(zaptest.NewLogger(t), dssync.MutexWrap(ds.NewMapDatastore()))
 	exch := offline.Exchange(bstore2)
-	bserv := NewWriteThrough(bstore, exch, zaptest.NewLogger(t))
+	bserv := New(bstore, exch, zaptest.NewLogger(t))
 	bgen := butil.NewBlockGenerator()
 
 	block := bgen.Next()
@@ -55,7 +55,7 @@ func TestLazySessionInitialization(t *testing.T) {
 	session := offline.Exchange(bstore2)
 	exchange := offline.Exchange(bstore3)
 	sessionExch := &fakeSessionExchange{Interface: exchange, session: session}
-	bservSessEx := NewWriteThrough(bstore, sessionExch, zaptest.NewLogger(t))
+	bservSessEx := New(bstore, sessionExch, zaptest.NewLogger(t))
 	bgen := butil.NewBlockGenerator()
 
 	block := bgen.Next()

--- a/blockservice_test.go
+++ b/blockservice_test.go
@@ -6,6 +6,7 @@ import (
 
 	blockstore "github.com/RTradeLtd/go-ipfs-blockstore/v2"
 	blocks "github.com/ipfs/go-block-format"
+	cid "github.com/ipfs/go-cid"
 	ds "github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
 	butil "github.com/ipfs/go-ipfs-blocksutil"
@@ -36,6 +37,8 @@ func TestBlockservice(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	// now test hash security
+	blocks.NewBlockWithCid([]byte("hello"), cid.Undef)
 }
 
 func TestWriteThroughWorks(t *testing.T) {

--- a/blockservice_test.go
+++ b/blockservice_test.go
@@ -194,6 +194,11 @@ func (bs *PutCountingBlockstore) Put(block blocks.Block) error {
 	return bs.Blockstore.Put(block)
 }
 
+func (bs *PutCountingBlockstore) PutMany(blks []blocks.Block) error {
+	bs.PutCounter += len(blks)
+	return bs.Blockstore.PutMany(blks)
+}
+
 var _ exchange.SessionExchange = (*fakeSessionExchange)(nil)
 
 type fakeSessionExchange struct {

--- a/blockservice_test.go
+++ b/blockservice_test.go
@@ -175,7 +175,7 @@ func TestLazySessionInitialization(t *testing.T) {
 	for blk := range blockChan {
 		switch blk.Cid() {
 		case block.Cid(), block2.Cid(), block3.Cid(), block4.Cid():
-			break
+			continue
 		default:
 			t.Fatal("bad block found")
 		}

--- a/blockservice_test.go
+++ b/blockservice_test.go
@@ -154,9 +154,28 @@ func TestLazySessionInitialization(t *testing.T) {
 	if bsession.ses != session {
 		t.Fatal("Should have initialized session to fetch block")
 	}
-	blockChan := bsession.GetBlocks(ctx, []cid.Cid{block.Cid(), block2.Cid()})
+	block3 := bgen.Next()
+	if err := bstore2.Put(block3); err != nil {
+		t.Fatal(err)
+	}
+	block4 := bgen.Next()
+	if err := bstore3.Put(block4); err != nil {
+		t.Fatal(err)
+	}
+	blockChan := bsession.GetBlocks(
+		ctx,
+		[]cid.Cid{block.Cid(),
+			block2.Cid(),
+			block3.Cid(),
+			block4.Cid(),
+			bgen.Next().Cid(),
+		},
+	)
 	for blk := range blockChan {
-		if blk.Cid() != block.Cid() && blk.Cid() != block2.Cid() {
+		switch blk.Cid() {
+		case block.Cid(), block2.Cid(), block3.Cid(), block4.Cid():
+			break
+		default:
 			t.Fatal("bad block found")
 		}
 	}

--- a/blockservice_test.go
+++ b/blockservice_test.go
@@ -151,6 +151,12 @@ func TestLazySessionInitialization(t *testing.T) {
 	if bsession.ses != session {
 		t.Fatal("Should have initialized session to fetch block")
 	}
+	blockChan := bsession.GetBlocks(ctx, []cid.Cid{block.Cid(), block2.Cid()})
+	for blk := range blockChan {
+		if blk.Cid() != block.Cid() && blk.Cid() != block2.Cid() {
+			t.Fatal("bad block found")
+		}
+	}
 }
 
 var _ blockstore.Blockstore = (*PutCountingBlockstore)(nil)

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,6 @@ require (
 	github.com/ipfs/go-ipfs-exchange-offline v0.0.1
 	github.com/ipfs/go-ipfs-routing v0.1.0
 	github.com/ipfs/go-ipfs-util v0.0.1
-	github.com/ipfs/go-log v1.0.4
-	github.com/ipfs/go-verifcid v0.0.1
 	github.com/libp2p/go-libp2p v0.8.3 // indirect
 	go.uber.org/zap v1.14.1
 )

--- a/session.go
+++ b/session.go
@@ -11,7 +11,9 @@ import (
 	"go.uber.org/zap"
 )
 
-var _ BlockGetter = (*Session)(nil)
+var (
+	_ BlockGetter = (*Session)(nil)
+)
 
 // Session is a helper type to provide higher level access to bitswap sessions
 type Session struct {


### PR DESCRIPTION
This essentially condenses the writethrough and non-writethrough blockservice into one. The underlying blockstore performs this check to prevent writting the same block to disk more than once. This "writethrough" concept is intended to prevent excessive network activity, however it will give us somewhat inaccurate reference counts.

In order to keep the minimal network activity, while also getting truly accurate reference counts, the "checkFirst" mechanic is used to determine what blocks we need to put through the exchange service.  All blocks regardless of whether we have them will be pushed through to the underlying blockstore. This is okay because the underlying blockstore we  use performs this check.

# Changes (tl;dr)

* Merge writethrough and non-writethrough mechanics
* Allow insecure hash functions as there may be situation where we want to use them
  * Ex: private swarm network, distributed checksum keys using md5
* Add more tests, this repo had very poor test coverage